### PR TITLE
Add release-notes for v1.1.15 and a prepare-release skill

### DIFF
--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: prepare-release
+description: Prepare a new NuGet release of Finance.NET — decide the next SemVer version, bump it, write the required release notes, and open the release PR to main. Use whenever the user mentions releasing, publishing, shipping, cutting a release, bumping the version for a release, or preparing release notes, even if they don't say "release" explicitly. Every release REQUIRES a release-notes/v<version>.md file; the deploy workflow reads it and fails without it.
+---
+
+# Prepare release
+
+Prepare a new release of the Finance.NET NuGet package. You decide the next
+version yourself, prepare the branch, and **open the release PR to `main` — then
+stop.** Merging and publishing are manual maintainer steps and not part of this
+skill:
+
+- You do **not** merge the release PR.
+- You do **not** trigger `deploy-nuget.yml`. Publishing is a manual
+  `workflow_dispatch` ("Deploy Nuget") the maintainer runs **after** merging.
+
+## The one thing that must not be forgotten
+
+`deploy-nuget.yml` creates the GitHub Release with
+`body_path: ./release-notes/v<version>.md` (see step "Create GitHub Release").
+**If that file does not exist, the deploy workflow fails.** So the release-notes
+file is not optional documentation — it is a hard requirement of every release.
+
+## Workflow
+
+1. **Confirm there is something to release.** Latest tag:
+   `git tag --sort=-v:refname | head -1`. Then `git log --oneline <tag>..HEAD`.
+   No commits since the tag → nothing to release, stop.
+
+2. **Read the current version** — `<Version>` in `src/Finance.NET.csproj`.
+
+3. **Decide the next version (SemVer)** from the commits since the last tag:
+   - **MAJOR** breaking public-API changes · **MINOR** new backwards-compatible
+     features · **PATCH** fixes, dependency updates, docs, internal refactors.
+   - The public API is only the interfaces, models, enums, `FinanceNetConfiguration`,
+     and `FinanceNetException`; services are `internal`, so refactors behind them
+     are PATCH. State the chosen version and a one-line reason.
+
+4. **Confirm a clean tree** — `git status --short`; if dirty, ask how to proceed.
+
+5. **Branch from an up-to-date `main`** — `git checkout main && git pull`, then
+   `git checkout -b release/v<version>`.
+
+6. **(Optional) Update the shipped library's NuGet packages** in
+   `src/Finance.NET.csproj` only (leave `tests`/`example` alone), then
+   `dotnet restore Finance.NET.slnx`.
+
+7. **Build & test green (required).**
+   - `dotnet build Finance.NET.slnx --configuration Release`
+   - `dotnet test tests/Tests.csproj --configuration Release --filter "TestCategory=Unit"`
+     (unit tests are deterministic; the `Integration` tests hit live provider
+     endpoints and are not a reliable local release gate).
+
+8. **Bump `<Version>`** in `src/Finance.NET.csproj`.
+
+9. **Update docs** — adjust `README.md` (e.g. version-specific notes, new
+   dependency versions) if the changes warrant it.
+
+10. **Write the release notes (required).** Copy
+    `.claude/skills/prepare-release/assets/release-notes.md` to
+    `release-notes/v<version>.md` and fill in the `### What's Changed` bullets with
+    **user-facing** notes (not raw commit subjects). Match the existing files in
+    `release-notes/` for tone and format.
+
+11. **Commit** — stage `src/Finance.NET.csproj`, any docs, and the new
+    `release-notes/v<version>.md`. Message: `release: v<version>`. Do **not** tag;
+    the deploy workflow creates the tag.
+
+12. **Push & open the PR to main — then stop.**
+    - `git push -u origin release/v<version>`
+    - `gh pr create --base main --head release/v<version> --title "release: v<version>" --body <notes>`
+
+13. **Report** the PR link and remind the maintainer: after they merge it, they
+    run **Actions → Deploy Nuget → Run workflow**. That workflow builds, tests,
+    packs, pushes to NuGet + GitHub Packages, tags `v<version>`, and creates the
+    GitHub Release from `release-notes/v<version>.md`. You do not trigger it.

--- a/.claude/skills/prepare-release/assets/release-notes.md
+++ b/.claude/skills/prepare-release/assets/release-notes.md
@@ -1,0 +1,10 @@
+### What's Changed
+
+* {{ ... user-facing change ... }}
+* Updated NuGet packages.
+
+<!--
+Write user-facing notes, not raw commit subjects. Remove bullets that don't apply.
+File name must be release-notes/v<version>.md — deploy-nuget.yml reads it as the
+GitHub Release body and fails if it is missing.
+-->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,3 +48,7 @@ All failures are wrapped in `FinanceNetException`.
 - Analyzers are enforced at build time (`EnforceCodeStyleInBuild`, SonarAnalyzer, `.editorconfig`); warnings will fail style checks in CI/SonarCloud.
 - Public API surfaces carry XML `<summary>` docs (`GenerateDocumentationFile` is on).
 - Unit tests mock `IHttpClientFactory` and feed fixture files from `tests/TestData/` (must be registered in `Tests.csproj` with `CopyToOutputDirectory`).
+
+## Releases
+
+The version is `<Version>` in `src/Finance.NET.csproj`; publishing is a manual `workflow_dispatch` (`deploy-nuget.yml`, "Deploy Nuget") that tags `v<version>`. Every release **requires** a `release-notes/v<version>.md` file (format `### What's Changed` + user-facing bullets) — the deploy's "Create GitHub Release" step reads it via `body_path` and **fails if it is missing**. Bumping the version without adding that file is the classic broken release. Use the `prepare-release` skill (`.claude/skills/prepare-release/`), which walks the version bump, notes, and release PR to `main`.

--- a/release-notes/v1.1.15.md
+++ b/release-notes/v1.1.15.md
@@ -1,0 +1,4 @@
+### What's Changed
+
+* Replaced the AutoMapper dependency with internal hand-written mapping, removing AutoMapper (and its transitive dependencies) from the package.
+* Updated NuGet packages.


### PR DESCRIPTION
PR #47 bumped the version to 1.1.15 without a release-notes/v1.1.15.md file, which deploy-nuget.yml reads via body_path and fails without. Add the missing notes file, plus a prepare-release skill and a CLAUDE.md Releases section so the notes step is not forgotten again.