### PR TITLE
Honour CancellationToken through the retry policy

### DIFF
--- a/src/Services/AlphaVantageService.cs
+++ b/src/Services/AlphaVantageService.cs
@@ -74,9 +74,9 @@ public class AlphaVantageService : IAlphaVantageService
 
         try
         {
-            var instrumentOverview = await _retryPolicy.ExecuteAsync(async () =>
+            var instrumentOverview = await _retryPolicy.ExecuteAsync(async ct =>
                 {
-                    var httpResponse = await httpClient.GetAsync(url, token).ConfigureAwait(false);
+                    var httpResponse = await httpClient.GetAsync(url, ct).ConfigureAwait(false);
                     httpResponse.EnsureSuccessStatusCode();
 
                     var jsonResponse = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -90,8 +90,12 @@ public class AlphaVantageService : IAlphaVantageService
                         var isNullObj = Helper.AreAllPropertiesNull(overview);
                         return isNullObj ? throw new FinanceNetException(Constants.ValidationMessageAllFieldsEmpty) : overview;
                     }
-                }).ConfigureAwait(false);
+                }, token).ConfigureAwait(false);
             return instrumentOverview;
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -119,16 +123,20 @@ public class AlphaVantageService : IAlphaVantageService
         }
         try
         {
-            return await _retryPolicy.ExecuteAsync(async () =>
+            return await _retryPolicy.ExecuteAsync(async ct =>
             {
-                var jsonResponse = await Helper.FetchJsonDocumentAsync(httpClient, _logger, url, token).ConfigureAwait(false);
+                var jsonResponse = await Helper.FetchJsonDocumentAsync(httpClient, _logger, url, ct).ConfigureAwait(false);
                 if (jsonResponse.Contains(Constants.ApiResponseLimitExceeded))
                 {
                     throw new FinanceNetException($"{Constants.ApiResponseLimitExceeded} for {symbol}");
                 }
                 var result = AlphaVantageParser.ParseRecords(symbol, startDate, endDate, jsonResponse, _logger);
                 return result.IsNullOrEmpty() ? throw new FinanceNetException(Constants.ValidationMessageAllFieldsEmpty) : result;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -183,9 +191,9 @@ public class AlphaVantageService : IAlphaVantageService
 
         try
         {
-            return await _retryPolicy.ExecuteAsync(async () =>
+            return await _retryPolicy.ExecuteAsync(async ct =>
             {
-                var response = await httpClient.GetAsync(url, token).ConfigureAwait(false);
+                var response = await httpClient.GetAsync(url, ct).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
 
                 var jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -195,7 +203,11 @@ public class AlphaVantageService : IAlphaVantageService
                 }
                 var result = AlphaVantageParser.ParseIntradayRecords(symbol, interval, jsonResponse);
                 return result.IsNullOrEmpty() ? throw new FinanceNetException(Constants.ValidationMessageAllFieldsEmpty) : result;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -225,9 +237,9 @@ public class AlphaVantageService : IAlphaVantageService
 
         try
         {
-            return await _retryPolicy.ExecuteAsync(async () =>
+            return await _retryPolicy.ExecuteAsync(async ct =>
             {
-                var jsonResponse = await Helper.FetchJsonDocumentAsync(httpClient, _logger, url, token).ConfigureAwait(false);
+                var jsonResponse = await Helper.FetchJsonDocumentAsync(httpClient, _logger, url, ct).ConfigureAwait(false);
                 if (jsonResponse.Contains(Constants.ApiResponseLimitExceeded))
                 {
                     throw new FinanceNetException($"{Constants.ApiResponseLimitExceeded} for {currency1} /{currency2}");
@@ -238,7 +250,11 @@ public class AlphaVantageService : IAlphaVantageService
                 }
                 var result = AlphaVantageParser.ParseForexRecords(currency1, currency2, startDate, endDate, jsonResponse, _logger);
                 return result.IsNullOrEmpty() ? throw new FinanceNetException(Constants.ValidationMessageAllFieldsEmpty) : result;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Services/DataHubService.cs
+++ b/src/Services/DataHubService.cs
@@ -32,9 +32,9 @@ public class DataHubService(IHttpClientFactory httpClientFactory,
         var config = new CsvConfiguration(CultureInfo.InvariantCulture);
         try
         {
-            return await _retryPolicy.ExecuteAsync(async () =>
+            return await _retryPolicy.ExecuteAsync(async ct =>
             {
-                var response = await httpClient.GetAsync(Constants.DatahubNasdaqSymbolsUrl, token).ConfigureAwait(false);
+                var response = await httpClient.GetAsync(Constants.DatahubNasdaqSymbolsUrl, ct).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
 
                 var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -43,7 +43,11 @@ public class DataHubService(IHttpClientFactory httpClientFactory,
                 csv.Context.RegisterClassMap<NasdaqInstrumentMapping>();
                 var instruments = csv.GetRecords<NasdaqInstrument>().ToList();
                 return instruments.IsNullOrEmpty() ? throw new FinanceNetException(Constants.ValidationMessageAllFieldsEmpty) : instruments;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -57,9 +61,9 @@ public class DataHubService(IHttpClientFactory httpClientFactory,
         var httpClient = _httpClientFactory.CreateClient(Constants.DatahubIoHttpClientName);
         try
         {
-            return await _retryPolicy.ExecuteAsync(async () =>
+            return await _retryPolicy.ExecuteAsync(async ct =>
             {
-                var response = await httpClient.GetAsync(Constants.DatahubSp500SymbolsUrl, token).ConfigureAwait(false);
+                var response = await httpClient.GetAsync(Constants.DatahubSp500SymbolsUrl, ct).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
                 var config = new CsvConfiguration(CultureInfo.InvariantCulture);
 
@@ -70,7 +74,11 @@ public class DataHubService(IHttpClientFactory httpClientFactory,
 
                 var instruments = csv.GetRecords<Sp500Instrument>().ToList();
                 return instruments.IsNullOrEmpty() ? throw new FinanceNetException(Constants.ValidationMessageAllFieldsEmpty) : instruments;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Services/XetraService.cs
+++ b/src/Services/XetraService.cs
@@ -44,10 +44,10 @@ public class XetraService : IXetraService
         var httpClient = _httpClientFactory.CreateClient(Constants.XetraHttpClientName);
         try
         {
-            return await _retryPolicy.ExecuteAsync(async () =>
+            return await _retryPolicy.ExecuteAsync(async ct =>
             {
-                var url = await GetDownloadUrl(token).ConfigureAwait(false);
-                var response = await httpClient.GetAsync(url, token).ConfigureAwait(false);
+                var url = await GetDownloadUrl(ct).ConfigureAwait(false);
+                var response = await httpClient.GetAsync(url, ct).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
                 var config = new CsvConfiguration(CultureInfo.InvariantCulture)
                 {
@@ -63,7 +63,7 @@ public class XetraService : IXetraService
                 csv.Context.RegisterClassMap<XetraInstrumentsMapping>();
 
                 var records = new List<InstrumentItem>();
-                await foreach (var record in csv.GetRecordsAsync<InstrumentItem>(token))
+                await foreach (var record in csv.GetRecordsAsync<InstrumentItem>(ct))
                 {
                     records.Add(record);
                 }
@@ -77,7 +77,11 @@ public class XetraService : IXetraService
                     .Where(instrument => !string.IsNullOrWhiteSpace(instrument.Mnemonic))
                     .ToList();
                 return result.IsNullOrEmpty() ? throw new FinanceNetException(Constants.ValidationMessageAllFieldsEmpty) : result;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -93,13 +97,17 @@ public class XetraService : IXetraService
 
         try
         {
-            return await _retryPolicy.ExecuteAsync(async () =>
+            return await _retryPolicy.ExecuteAsync(async ct =>
             {
-                var document = await Helper.FetchHtmlDocumentAsync(httpClient, _logger, url, token).ConfigureAwait(false);
+                var document = await Helper.FetchHtmlDocumentAsync(httpClient, _logger, url, ct).ConfigureAwait(false);
                 var hrefAttributes = document.DocumentElement.SelectNodes("//a[contains(@class, 'download') and contains(., 'All tradable instruments')]/@href")?.Select(e => e.NodeValue);
                 var relativeDownloadUrl = hrefAttributes?.FirstOrDefault();
                 return new Uri(baseUri, relativeDownloadUrl);
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Services/YahooFinanceService.cs
+++ b/src/Services/YahooFinanceService.cs
@@ -65,6 +65,10 @@ public class YahooFinanceService : IYahooFinanceService
                 }).ConfigureAwait(false);
                 result.AddRange(instruments);
             }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to load {Type}", instrumentType);
@@ -91,11 +95,11 @@ public class YahooFinanceService : IYahooFinanceService
             $"&crumb={crumb}";
         try
         {
-            return await _retryPolicy.ExecuteAsync(async () =>
+            return await _retryPolicy.ExecuteAsync(async ct =>
             {
                 var quotes = new List<Quote>();
 
-                var jsonContent = await Helper.FetchJsonDocumentAsync(httpClient, _logger, url, token).ConfigureAwait(false);
+                var jsonContent = await Helper.FetchJsonDocumentAsync(httpClient, _logger, url, ct).ConfigureAwait(false);
                 var parsedData = JsonConvert.DeserializeObject<QuoteResponseRoot>(jsonContent) ?? throw new FinanceNetException("Invalid data returned by Yahoo");
                 var responseObj = parsedData.QuoteResponse ?? throw new FinanceNetException("Invalid content from Yahoo");
 
@@ -119,7 +123,11 @@ public class YahooFinanceService : IYahooFinanceService
                     quotes.Add(quote);
                 }
                 return quotes;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -144,14 +152,18 @@ public class YahooFinanceService : IYahooFinanceService
         var url = $"{Constants.YahooQuoteHtmlUrl}/{symbol}/history/?period1={period1}&period2={period2}".ToLowerInvariant();
         try
         {
-            return await _retryPolicy.ExecuteAsync(async () =>
+            return await _retryPolicy.ExecuteAsync(async ct =>
             {
-                var document = await Helper.FetchHtmlDocumentAsync(httpClient, _logger, url, token).ConfigureAwait(false);
+                var document = await Helper.FetchHtmlDocumentAsync(httpClient, _logger, url, ct).ConfigureAwait(false);
 
-                await CheckAndDeclineConsentAsync(document, token).ConfigureAwait(false);
+                await CheckAndDeclineConsentAsync(document, ct).ConfigureAwait(false);
                 var records = YahooHtmlParser.ParseHistoryRecords(document, _logger);
                 return records.IsNullOrEmpty() ? throw new FinanceNetException(Constants.ValidationMessageAllFieldsEmpty) : records;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -187,13 +199,17 @@ public class YahooFinanceService : IYahooFinanceService
 
         try
         {
-            return await _retryPolicy.ExecuteAsync(async () =>
+            return await _retryPolicy.ExecuteAsync(async ct =>
             {
-                var document = await Helper.FetchHtmlDocumentAsync(httpClient, _logger, url, token).ConfigureAwait(false);
-                await CheckAndDeclineConsentAsync(document, token).ConfigureAwait(false);
+                var document = await Helper.FetchHtmlDocumentAsync(httpClient, _logger, url, ct).ConfigureAwait(false);
+                await CheckAndDeclineConsentAsync(document, ct).ConfigureAwait(false);
                 var result = YahooHtmlParser.ParseProfile(document);
                 return result;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -210,13 +226,17 @@ public class YahooFinanceService : IYahooFinanceService
 
         try
         {
-            return await _retryPolicy.ExecuteAsync(async () =>
+            return await _retryPolicy.ExecuteAsync(async ct =>
             {
-                var document = await Helper.FetchHtmlDocumentAsync(httpClient, _logger, url, token).ConfigureAwait(false);
-                await CheckAndDeclineConsentAsync(document, token).ConfigureAwait(false);
+                var document = await Helper.FetchHtmlDocumentAsync(httpClient, _logger, url, ct).ConfigureAwait(false);
+                await CheckAndDeclineConsentAsync(document, ct).ConfigureAwait(false);
                 var result = YahooHtmlParser.ParseFinancialReports(document, _logger);
                 return result;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -233,13 +253,17 @@ public class YahooFinanceService : IYahooFinanceService
 
         try
         {
-            return await _retryPolicy.ExecuteAsync(async () =>
+            return await _retryPolicy.ExecuteAsync(async ct =>
             {
-                var document = await Helper.FetchHtmlDocumentAsync(httpClient, _logger, url, token).ConfigureAwait(false);
-                await CheckAndDeclineConsentAsync(document, token).ConfigureAwait(false);
+                var document = await Helper.FetchHtmlDocumentAsync(httpClient, _logger, url, ct).ConfigureAwait(false);
+                await CheckAndDeclineConsentAsync(document, ct).ConfigureAwait(false);
                 var result = YahooHtmlParser.ParseSummary(document, _logger);
                 return result;
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -258,15 +282,15 @@ public class YahooFinanceService : IYahooFinanceService
             for (var i = 0; i < 100; i++)
             {
                 var url = $"{baseUrl}?start={i * 100}&count=100".ToLowerInvariant();
-                var items = await _retryPolicy.ExecuteAsync(async () =>
+                var items = await _retryPolicy.ExecuteAsync(async ct =>
                 {
-                    var document = await Helper.FetchHtmlDocumentAsync(httpClient, _logger, url, token).ConfigureAwait(false);
-                    await CheckAndDeclineConsentAsync(document, token).ConfigureAwait(false);
+                    var document = await Helper.FetchHtmlDocumentAsync(httpClient, _logger, url, ct).ConfigureAwait(false);
+                    await CheckAndDeclineConsentAsync(document, ct).ConfigureAwait(false);
                     var parsed = YahooHtmlParser.ParseSymbols(document, instrumentType, _logger);
                     return Helper.AreAllPropertiesNull(parsed)
                         ? throw new FinanceNetException(Constants.ValidationMessageAllFieldsEmpty)
                         : parsed;
-                }).ConfigureAwait(false);
+                }, token).ConfigureAwait(false);
 
                 result.AddRange(items.Where(e => e.Symbol != null));
                 result = result
@@ -281,6 +305,10 @@ public class YahooFinanceService : IYahooFinanceService
             }
 
             return result;
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch
         {

--- a/src/Utilities/YahooSessionManager.cs
+++ b/src/Utilities/YahooSessionManager.cs
@@ -56,16 +56,20 @@ internal class YahooSessionManager(ILogger<YahooSessionManager> logger,
         await Semaphore.WaitAsync(token).ConfigureAwait(false);
         try
         {
-            await _retryPolicy.ExecuteAsync(async () =>
+            await _retryPolicy.ExecuteAsync(async ct =>
             {
-                var crumb = await CreateApiCookiesAndCrumb(token).ConfigureAwait(false);
+                var crumb = await CreateApiCookiesAndCrumb(ct).ConfigureAwait(false);
                 _sessionState.SetCrumb(crumb, DateTime.UtcNow);
-                await CreateUiCookies(token).ConfigureAwait(false);
+                await CreateUiCookies(ct).ConfigureAwait(false);
                 if (!_sessionState.IsValid())
                 {
                     throw new FinanceNetException("cannot fetch Yahoo credentials");
                 }
-            }).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/tests/Services/CancellationTokenPropagationTests.cs
+++ b/tests/Services/CancellationTokenPropagationTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Finance.Net.Interfaces;
+using Finance.Net.Services;
+using Finance.Net.Utilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+using Polly;
+using Polly.Registry;
+
+namespace Finance.Net.Tests.Services;
+
+/// <summary>
+/// The retry policy sleeps between attempts. Those sleeps must observe the caller's
+/// <see cref="CancellationToken"/>, otherwise a cancelled call keeps running for the full
+/// back-off budget. Each test cancels shortly after the call starts and asserts the call
+/// gives up well before the policy would have finished sleeping.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+public class CancellationTokenPropagationTests
+{
+    private const int RetryCount = 3;
+    private static readonly TimeSpan RetrySleep = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan CancelAfter = TimeSpan.FromMilliseconds(150);
+
+    /// <summary>Comfortably below the first back-off sleep, comfortably above the cancel delay.</summary>
+    private static readonly TimeSpan MaxAcceptable = TimeSpan.FromMilliseconds(1500);
+
+    private Mock<IHttpClientFactory> _mockHttpClientFactory;
+    private Mock<IReadOnlyPolicyRegistry<string>> _mockPolicyRegistry;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // Always fails, so the policy always reaches its back-off sleep.
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("transient"));
+
+        _mockHttpClientFactory = new Mock<IHttpClientFactory>();
+        _mockHttpClientFactory.Setup(e => e.CreateClient(It.IsAny<string>())).Returns(new HttpClient(mockHandler.Object));
+
+        AsyncPolicy policy = Policy.Handle<Exception>().WaitAndRetryAsync(RetryCount, _ => RetrySleep);
+        IAsyncPolicy asyncPolicy = policy;
+
+        _mockPolicyRegistry = new Mock<IReadOnlyPolicyRegistry<string>>();
+        _mockPolicyRegistry.Setup(registry => registry.Get<AsyncPolicy>(Constants.DefaultHttpRetryPolicy)).Returns(policy);
+        _mockPolicyRegistry.Setup(registry => registry.Get<IAsyncPolicy>(Constants.DefaultHttpRetryPolicy)).Returns(policy);
+        _mockPolicyRegistry.Setup(registry => registry.TryGet(Constants.DefaultHttpRetryPolicy, out asyncPolicy)).Returns(true);
+    }
+
+    [Test]
+    public void GetQuotesAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var mockSession = new Mock<IYahooSessionManager>();
+        var service = new YahooFinanceService(
+            Mock.Of<ILogger<YahooFinanceService>>(),
+            _mockHttpClientFactory.Object,
+            _mockPolicyRegistry.Object,
+            mockSession.Object);
+
+        AssertCancelsPromptly(token => service.GetQuotesAsync(["IBM"], token));
+    }
+
+    [Test]
+    public void GetRecordsAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var mockSession = new Mock<IYahooSessionManager>();
+        var service = new YahooFinanceService(
+            Mock.Of<ILogger<YahooFinanceService>>(),
+            _mockHttpClientFactory.Object,
+            _mockPolicyRegistry.Object,
+            mockSession.Object);
+
+        AssertCancelsPromptly(token => service.GetRecordsAsync("IBM", new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), null, token));
+    }
+
+    [Test]
+    public void AlphaVantage_GetRecordsAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var mockOptions = new Mock<IOptions<FinanceNetConfiguration>>();
+        mockOptions.Setup(x => x.Value).Returns(new FinanceNetConfiguration());
+        var service = new AlphaVantageService(
+            Mock.Of<ILogger<AlphaVantageService>>(),
+            _mockHttpClientFactory.Object,
+            mockOptions.Object,
+            _mockPolicyRegistry.Object);
+
+        AssertCancelsPromptly(token => service.GetRecordsAsync("IBM", new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), null, token));
+    }
+
+    [Test]
+    public void Xetra_GetInstrumentsAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var service = new XetraService(
+            Mock.Of<ILogger<XetraService>>(),
+            _mockHttpClientFactory.Object,
+            _mockPolicyRegistry.Object);
+
+        AssertCancelsPromptly(service.GetInstrumentsAsync);
+    }
+
+    [Test]
+    public void DataHub_GetNasdaqInstrumentsAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var service = new DataHubService(_mockHttpClientFactory.Object, _mockPolicyRegistry.Object);
+
+        AssertCancelsPromptly(service.GetNasdaqInstrumentsAsync);
+    }
+
+    [Test]
+    public void RefreshSessionAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var mockState = new Mock<IYahooSessionState>();
+        mockState.Setup(e => e.IsValid()).Returns(false);
+        mockState.Setup(e => e.GetCookieContainer()).Returns(new System.Net.CookieContainer());
+        var manager = new YahooSessionManager(
+            Mock.Of<ILogger<YahooSessionManager>>(),
+            _mockHttpClientFactory.Object,
+            mockState.Object,
+            _mockPolicyRegistry.Object);
+
+        AssertCancelsPromptly(manager.RefreshSessionAsync);
+    }
+
+    private static void AssertCancelsPromptly(Func<CancellationToken, Task> call)
+    {
+        using var cts = new CancellationTokenSource(CancelAfter);
+        var stopwatch = Stopwatch.StartNew();
+
+        Assert.CatchAsync<OperationCanceledException>(async () => await call(cts.Token));
+
+        stopwatch.Stop();
+        Assert.That(stopwatch.Elapsed, Is.LessThan(MaxAcceptable),
+            $"call kept running for {stopwatch.ElapsedMilliseconds}ms after cancellation - the token never reached the retry back-off");
+    }
+}


### PR DESCRIPTION
Every public API accepts a `CancellationToken`, but cancellation currently has no effect: the token is never handed to Polly, so the back-off sleeps between retries are uninterruptible.

The token *does* reach `HttpClient.SendAsync`, so an in-flight request is cancellable. But with the default configuration (`HttpRetryCount = 10`, `HttpTimeout = 20`, the latter also used as the linear back-off base) a failing call spends the overwhelming majority of its time asleep between attempts — exactly where the token cannot reach. A caller with a 20 s budget was still running well past 75 s.

## Cause

All call sites use `ExecuteAsync(Func<Task<T>>)`, the overload that takes no `CancellationToken`:

```csharp
return await _retryPolicy.ExecuteAsync(async () =>
{
    var document = await Helper.FetchHtmlDocumentAsync(httpClient, _logger, url, token)...
```

## Changes

- Switch all 15 `_retryPolicy.ExecuteAsync` sites to the token-aware overload, and use the token Polly hands the delegate rather than capturing the outer one. For the bare retry policy registered today these are the same token, but the call sites resolve an opaque `AsyncPolicy` from the registry — if a timeout or circuit breaker is ever wrapped around it, the captured-token version would silently keep waiting.

  | File | Sites |
  |---|---|
  | `src/Services/YahooFinanceService.cs` | 6 |
  | `src/Services/AlphaVantageService.cs` | 4 |
  | `src/Services/XetraService.cs` | 2 |
  | `src/Services/DataHubService.cs` | 2 |
  | `src/Utilities/YahooSessionManager.cs` | 1 |

- Stop swallowing cancellation in the surrounding error handling. Each catch-all that wrapped everything in `FinanceNetException` now rethrows `OperationCanceledException` when the caller's token was cancelled:

  ```csharp
  catch (OperationCanceledException) when (token.IsCancellationRequested)
  {
      throw;
  }
  ```

  Without this the fix above would still surface as `FinanceNetException`. The guard is deliberately narrow — cancellation is only rethrown when the *caller* cancelled, so an `HttpClient` timeout (`TaskCanceledException`) is still wrapped exactly as before.

- `YahooFinanceService.GetInstrumentsAsync` and `FetchSymbolsAsync` no longer degrade cancellation into a logged warning or a partial result.

## Tests

Adds `CancellationTokenPropagationTests`: six entry points across all four services and the session manager, each cancelled 150 ms into a call whose policy is configured to sleep 2 s between attempts. Each test asserts an `OperationCanceledException` and that the call gave up well before the back-off would have elapsed.

Against the current code all six fail with `FinanceNetException` after sleeping out the full retry budget — the fixture takes a full minute. With the fix it takes about a second.

`TestCategory=Unit` passes: 162 tests, 0 failures. No new analyzer warnings.

## Note

Only the cancellation problem is addressed here, deliberately kept to one concern. The back-off sizing (`HttpTimeout` doubling as the retry back-off base) and the retrying of empty result sets are separate issues that compound with this one; I have fixes for those on separate branches and can open them as follow-up PRs if useful.

---

These changes were generated with [Claude Code](https://claude.com/claude-code), and I have reviewed them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
