### PR TITLE
Fix review findings from #55-#58 and release 1.2.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,8 @@ root = true
 # tab_width = 2
 [*.{cs,vb}]
 
-indent_size = 4				  
+charset = utf-8-bom
+indent_size = 4
 indent_style = space
 tab_width = 4				  
 insert_final_newline = false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,12 +36,12 @@ Entry point is `ServiceCollectionExtensions.AddFinanceNet()` (src/Extensions), w
 
 - Four scoped services in `src/Services/` behind public interfaces in `src/Interfaces/`: `YahooFinanceService`, `AlphaVantageService`, `XetraService`, `DataHubService`. Services are `internal`; only interfaces, models, enums, config (`FinanceNetConfiguration`), and the exception are public API.
 - One named `HttpClient` per provider (names in `src/Constants.cs`, which also holds all provider URLs). Each client gets a randomized User-Agent (`Helper.CreateRandomUserAgent`).
-- A shared Polly retry policy (`PollyPolicyFactory`) registered in a `PolicyRegistry` under `Constants.DefaultHttpRetryPolicy`; services resolve it from the registry and wrap their HTTP calls with it. Retry count and back-off base (`HttpRetryCount`, `HttpRetrySleepTime`) come from `FinanceNetConfiguration`; `HttpTimeout` is the HTTP client timeout only and must not be reused as the back-off base.
+- A shared Polly retry policy (`PollyPolicyFactory`) registered in a `PolicyRegistry` under `Constants.DefaultHttpRetryPolicy`; services resolve it from the registry and wrap their HTTP calls with it. Retry count and back-off base (`HttpRetryCount`, `HttpRetrySleepTime`) come from `FinanceNetConfiguration`; `HttpTimeout` is the HTTP client timeout only and must not be reused as the back-off base. The back-off grows exponentially from the base, is capped at `PollyPolicyFactory.MaxRetryDelaySecs` (30s) per attempt, and carries jitter of up to one full delay.
 - Internal DTOs (`src/Models/*/Dtos/`) are converted to the public models (`src/Models/*/`) by hand-written extension-method mappers in `src/Mappings/` (`YahooQuoteMapper.ToQuote`, `XetraInstrumentMapper.ToInstrument`). The `*Mapping.cs` classes in the same folder are CsvHelper `ClassMap`s, not object-to-object mappers.
 
 Yahoo requires session state: `YahooSessionState` and `YahooSessionManager` (singletons in `src/Utilities/`) fetch consent cookies and an API "crumb", guarded by a semaphore, valid for 6 hours. The Yahoo HttpClient shares the session's `CookieContainer`. HTML parsing uses AngleSharp with XPath (`YahooHtmlParser`); Alpha Vantage JSON parsing is in `AlphaVantageParser`; CSV parsing uses CsvHelper.
 
-All failures are wrapped in `FinanceNetException`.
+All failures surface as `FinanceNetException`. A provider that answered correctly but with no rows throws `FinanceNetNoDataException` (which derives from it) and is deliberately **not** wrapped, so `InnerException` is null there; the retry policy skips it. Everything else - transport errors, an unexpected page, malformed content - stays retryable and keeps its inner exception.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ services.AddFinanceNet(new FinanceNetConfiguration
 {
     HttpTimeout = 5,          // seconds (default: 20)
     HttpRetryCount = 3,       // default: 10
-    HttpRetrySleepTime = 1,   // seconds, base for exponential back-off (default: 1)
+    HttpRetrySleepTime = 5,   // seconds, base for exponential back-off; capped at 30s per attempt, plus jitter (default: 5)
     AlphaVantageApiKey = "ALPHA_VANTAGE__API_KEY"
 });
 ```

--- a/release-notes/v1.2.0.md
+++ b/release-notes/v1.2.0.md
@@ -1,0 +1,15 @@
+### What's Changed
+
+* `CancellationToken` now reaches the retry policy. Cancelling a call interrupts the back-off sleeps instead of running to the end of the retry budget, and surfaces as `OperationCanceledException` rather than `FinanceNetException`.
+* New `FinanceNetNoDataException` (derives from `FinanceNetException`) for a provider that answered correctly but returned no rows. It is excluded from the retry policy, so an unknown symbol fails immediately instead of burning the whole back-off budget. It is not wrapped, so `InnerException` is null and the message differs from the previous wrapper text.
+* New `FinanceNetConfiguration.HttpRetrySleepTime` (default 5 seconds) as the retry back-off base. Previously `HttpTimeout` doubled as the back-off base, so raising the HTTP timeout silently lengthened every retry. The back-off now grows exponentially from this base, is capped at 30 seconds per attempt and carries jitter.
+* Default retry behaviour changed for every caller: a fully failing call now spends roughly 3 minutes in back-off instead of roughly 18 minutes.
+* `GetQuotesAsync` logs a warning naming the symbols Yahoo silently dropped from a batch request.
+* A Yahoo consent page or any other unexpected page is retried again instead of being reported as "no data", so the consent cookie gets a second chance to take effect.
+* A provider outage during `GetInstrumentsAsync` now surfaces as `FinanceNetException` with the transport error attached, instead of claiming the instrument catalogue is permanently empty.
+
+### Breaking Changes
+
+* Cancellation escapes as `OperationCanceledException`. A caller that relied on a single `catch (FinanceNetException)` covering everything must add a cancellation branch.
+* On no-data paths the exception message changed and `InnerException` is now null. Code matching on the exact type `FinanceNetException` (rather than catching it) or parsing messages needs updating.
+* Default retry timing changed as described above.

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -15,7 +15,6 @@ internal static class Constants
     // Messages
     public const string ApiResponseLimitExceeded = "higher API call volume";
     public const string ApiResponseApiKeyInvalid = "apikey is invalid";
-    public const string ValidationMessageAllFieldsEmpty = "All fields empty";
 
     #region Yahoo Finance
 

--- a/src/Finance.NET.csproj
+++ b/src/Finance.NET.csproj
@@ -12,7 +12,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 	<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 	<PackageId>Finance.NET</PackageId>
-	<Version>1.1.15</Version>
+	<Version>1.2.0</Version>
 	<Authors>Thorsten Alpers</Authors>
 	<Owners>Thorsten Alpers</Owners>
 	<Description>A .NET library for retrieving real-time and historical financial data from Yahoo Finance and other popular sources.</Description>

--- a/src/FinanceNetConfiguration.cs
+++ b/src/FinanceNetConfiguration.cs
@@ -14,11 +14,11 @@ public class FinanceNetConfiguration
     [Required] public int HttpTimeout { get; set; } = 20;
 
     /// <summary>
-    /// Base wait between retries in seconds, default 1 second. Retries back off
-    /// exponentially from this base (1s, 2s, 4s, ...) with jitter, capped per attempt.
-    /// Set to 0 to retry without waiting.
+    /// Base wait between retries in seconds, default 5 seconds. Retries back off
+    /// exponentially from this base (5s, 10s, 20s, ...) with jitter, capped at 30 seconds
+    /// per attempt. Set to 0 to retry without waiting.
     /// </summary>
-    [Required] public int HttpRetrySleepTime { get; set; } = 1;
+    [Required] public int HttpRetrySleepTime { get; set; } = 5;
 
     /// <summary> Alpha Vantage API Key, default null </summary>
     public string? AlphaVantageApiKey { get; set; }

--- a/src/Services/AlphaVantageService.cs
+++ b/src/Services/AlphaVantageService.cs
@@ -52,14 +52,14 @@ public class AlphaVantageService : IAlphaVantageService
                     (ex, ts, retryCount, ctx) =>
                     {
                         _logger.LogWarning(
-                            "Retry {RetryCount} wegen {Reason}, warte {Delay}s",
+                            "Retry {RetryCount} due to {Reason}, waiting {Delay}s",
                             retryCount,
-                            ex?.Message ?? "Unbekannt",
+                            ex?.Message ?? "unknown",
                             ts.TotalSeconds);
                     });
 
             _logger.LogWarning(
-                "Retry-Policy '{PolicyKey}' nicht gefunden – verwende Default (3x Retry, Backoff).",
+                "Retry policy '{PolicyKey}' not found - falling back to the default (3 retries, back-off).",
                 Constants.DefaultHttpRetryPolicy);
         }
     }

--- a/src/Services/XetraService.cs
+++ b/src/Services/XetraService.cs
@@ -69,7 +69,7 @@ public class XetraService : IXetraService
                 }
                 if (records.Count == 0)
                 {
-                    throw new FinanceNetNoDataException("CSV liefert keine InstrumentItem-Daten.");
+                    throw new FinanceNetNoDataException("Xetra CSV contains no instrument rows");
                 }
 
                 var result = records
@@ -109,7 +109,7 @@ public class XetraService : IXetraService
         {
             throw;
         }
-        catch (Exception ex) when (ex is not FinanceNetNoDataException)
+        catch (Exception ex)
         {
             throw new FinanceNetException($"Cannot fetch from {Constants.XetraInstrumentsUrl}", ex);
         }

--- a/src/Services/YahooFinanceService.cs
+++ b/src/Services/YahooFinanceService.cs
@@ -49,6 +49,7 @@ public class YahooFinanceService : IYahooFinanceService
                                          .ToList();
 
         var typesToProcess = filterByType == null ? instrumentTypes : [filterByType.Value];
+        Exception? lastFailure = null;
 
         foreach (var instrumentType in typesToProcess)
         {
@@ -69,12 +70,25 @@ public class YahooFinanceService : IYahooFinanceService
             {
                 throw;
             }
+            catch (FinanceNetNoDataException ex)
+            {
+                _logger.LogWarning(ex, "No data for {Type}", instrumentType);
+            }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to load {Type}", instrumentType);
+                lastFailure = ex;
             }
         }
-        return result.IsNullOrEmpty() ? throw new FinanceNetNoDataException("No instruments found") : result;
+        if (!result.IsNullOrEmpty())
+        {
+            return result;
+        }
+        // A transport failure is not a permanent no-data answer - reporting it as one would tell
+        // the caller to stop asking while Yahoo is merely down.
+        throw lastFailure is null
+            ? new FinanceNetNoDataException("No instruments found")
+            : new FinanceNetException("No instruments found", lastFailure);
     }
 
     /// <inheritdoc />
@@ -93,11 +107,12 @@ public class YahooFinanceService : IYahooFinanceService
         var url = $"{Constants.YahooQuoteApiUrl}?" +
             $"&symbols={string.Join(",", symbols).ToLowerInvariant()}" +
             $"&crumb={crumb}";
+        List<Quote> quotes;
         try
         {
-            var quotes = await _retryPolicy.ExecuteAsync(async ct =>
+            quotes = await _retryPolicy.ExecuteAsync(async ct =>
             {
-                var quotes = new List<Quote>();
+                var fetched = new List<Quote>();
 
                 var jsonContent = await Helper.FetchJsonDocumentAsync(httpClient, _logger, url, ct).ConfigureAwait(false);
                 var parsedData = JsonConvert.DeserializeObject<QuoteResponseRoot>(jsonContent) ?? throw new FinanceNetException("Invalid data returned by Yahoo");
@@ -120,13 +135,10 @@ public class YahooFinanceService : IYahooFinanceService
                         throw new FinanceNetException("Invalid quote field symbol");
                     }
                     var quote = quoteResponse.ToQuote();
-                    quotes.Add(quote);
+                    fetched.Add(quote);
                 }
-                return quotes;
+                return fetched;
             }, token).ConfigureAwait(false);
-
-            WarnAboutUnresolvedSymbols(symbols, quotes);
-            return quotes;
         }
         catch (OperationCanceledException) when (token.IsCancellationRequested)
         {
@@ -136,17 +148,21 @@ public class YahooFinanceService : IYahooFinanceService
         {
             throw new FinanceNetException("No way to fetch quotes", ex);
         }
+
+        // Outside the try on purpose: a throwing logging sink must not turn a fetch that
+        // already succeeded into a FinanceNetException.
+        WarnAboutUnresolvedSymbols(symbols, quotes);
+        return quotes;
     }
 
-    /// <summary>
-    /// Yahoo silently omits symbols it cannot resolve. Report the shortfall, so a caller
-    /// doing a scheduled refresh can spot bad tickers without diffing the request itself.
-    /// </summary>
     private void WarnAboutUnresolvedSymbols(List<string> requested, List<Quote> quotes)
     {
         // Symbol is never null here - a null one is rejected while building the list above.
         var resolved = new HashSet<string>(quotes.Select(quote => quote.Symbol!), StringComparer.OrdinalIgnoreCase);
-        var unresolved = requested.Where(symbol => !resolved.Contains(symbol)).ToList();
+        var unresolved = requested
+            .Where(symbol => !resolved.Contains(symbol))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
         if (unresolved.Count != 0)
         {
             _logger.LogWarning("Yahoo returned no data for {Count} of {RequestedCount} requested symbols: {Symbols}",

--- a/src/Utilities/PollyPolicyFactory.cs
+++ b/src/Utilities/PollyPolicyFactory.cs
@@ -29,7 +29,7 @@ internal static class PollyPolicyFactory
 
     /// <summary>
     /// Exponential back-off from <paramref name="baseWaitTimeSecs"/> (1x, 2x, 4x, ...), capped at
-    /// <see cref="MaxRetryDelaySecs"/>, plus up to one base interval of jitter so concurrent
+    /// <see cref="MaxRetryDelaySecs"/>, plus up to one full delay of jitter so concurrent
     /// callers do not retry in lockstep.
     /// </summary>
     internal static TimeSpan GetRetryDelay(int retryAttempt, int baseWaitTimeSecs)
@@ -40,7 +40,9 @@ internal static class PollyPolicyFactory
         }
         var exponent = Math.Min(retryAttempt - 1, 30);  // keep Pow away from infinity
         var backOffSecs = Math.Min(baseWaitTimeSecs * Math.Pow(2, exponent), MaxRetryDelaySecs);
-        var jitterMs = RandomNumberGenerator.GetInt32(0, baseWaitTimeSecs * 1000);
+        // Jitter scales with the delay, not with the base: once the cap is reached a
+        // base-sized window would put every caller back into lockstep.
+        var jitterMs = RandomNumberGenerator.GetInt32(0, (int)(backOffSecs * 1000));
         return TimeSpan.FromSeconds(backOffSecs) + TimeSpan.FromMilliseconds(jitterMs);
     }
 }

--- a/src/Utilities/YahooHtmlParser.cs
+++ b/src/Utilities/YahooHtmlParser.cs
@@ -16,8 +16,19 @@ namespace Finance.Net.Utilities;
 /// <inheritdoc />
 internal static class YahooHtmlParser
 {
+    // Profile and Summary have no required field, so without this an unexpected page - a
+    // consent interstitial above all - parses as "well-formed but empty" and stops being retried.
+    private static void EnsureQuotePage(IHtmlDocument document, string page)
+    {
+        if (document.Body.SelectSingleNode("//section/h1") is null)
+        {
+            throw new FinanceNetException($"Yahoo did not return the {page} page");
+        }
+    }
+
     public static Profile ParseProfile(IHtmlDocument document)
     {
+        EnsureQuotePage(document, "profile");
         var descriptionElement = document.Body.SelectSingleNode("//section[header/h3[contains(text(), 'Description') or contains(text(), 'Summary')]]/p\n");
         var cntEmployeesElement = document.Body.SelectSingleNode("//dt[contains(text(), 'Employees')]/following-sibling::dd");
         var industryElement = document.Body.SelectSingleNode("//dt[contains(text(), 'Industry')]/following-sibling::a");
@@ -181,6 +192,7 @@ internal static class YahooHtmlParser
 
     public static Summary ParseSummary<T>(IHtmlDocument document, ILogger<T> logger)
     {
+        EnsureQuotePage(document, "summary");
         var nameElement = document.Body.SelectSingleNode("//section/h1");
         var name = Helper.RemoveSymbolHeader(nameElement?.TextContent?.Trim());
 

--- a/tests/Services/CancellationTokenPropagationTests.cs
+++ b/tests/Services/CancellationTokenPropagationTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Finance.Net.Enums;
 using Finance.Net.Interfaces;
 using Finance.Net.Services;
 using Finance.Net.Utilities;
@@ -31,8 +32,11 @@ public class CancellationTokenPropagationTests
     private static readonly TimeSpan RetrySleep = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan CancelAfter = TimeSpan.FromMilliseconds(150);
 
-    /// <summary>Comfortably below the first back-off sleep, comfortably above the cancel delay.</summary>
-    private static readonly TimeSpan MaxAcceptable = TimeSpan.FromMilliseconds(1500);
+    // Below the 2s back-off sleep, but with enough headroom for a CI runner under coverage
+    // instrumentation - the exception type already separates fixed from broken on its own.
+    private static readonly TimeSpan MaxAcceptable = TimeSpan.FromMilliseconds(1900);
+
+    private static readonly DateTime StartDate = new(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
     private Mock<IHttpClientFactory> _mockHttpClientFactory;
     private Mock<IReadOnlyPolicyRegistry<string>> _mockPolicyRegistry;
@@ -86,17 +90,74 @@ public class CancellationTokenPropagationTests
     }
 
     [Test]
+    public void GetInstrumentsAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var mockSession = new Mock<IYahooSessionManager>();
+        var service = new YahooFinanceService(
+            Mock.Of<ILogger<YahooFinanceService>>(),
+            _mockHttpClientFactory.Object,
+            _mockPolicyRegistry.Object,
+            mockSession.Object);
+
+        // Unfiltered, so cancellation has to escape both the per-type log-and-continue loop
+        // and the partial-result catch in FetchSymbolsAsync.
+        AssertCancelsPromptly(token => service.GetInstrumentsAsync(null, token));
+    }
+
+    [Test]
+    public void GetProfileAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var service = CreateYahooService();
+
+        AssertCancelsPromptly(token => service.GetProfileAsync("IBM", token));
+    }
+
+    [Test]
+    public void GetSummaryAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var service = CreateYahooService();
+
+        AssertCancelsPromptly(token => service.GetSummaryAsync("IBM", token));
+    }
+
+    [Test]
+    public void GetFinancialsAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var service = CreateYahooService();
+
+        AssertCancelsPromptly(token => service.GetFinancialsAsync("IBM", token));
+    }
+
+    [Test]
     public void AlphaVantage_GetRecordsAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
     {
-        var mockOptions = new Mock<IOptions<FinanceNetConfiguration>>();
-        mockOptions.Setup(x => x.Value).Returns(new FinanceNetConfiguration());
-        var service = new AlphaVantageService(
-            Mock.Of<ILogger<AlphaVantageService>>(),
-            _mockHttpClientFactory.Object,
-            mockOptions.Object,
-            _mockPolicyRegistry.Object);
+        var service = CreateAlphaVantageService();
 
-        AssertCancelsPromptly(token => service.GetRecordsAsync("IBM", new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), null, token));
+        AssertCancelsPromptly(token => service.GetRecordsAsync("IBM", StartDate, null, token));
+    }
+
+    [Test]
+    public void AlphaVantage_GetOverviewAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var service = CreateAlphaVantageService();
+
+        AssertCancelsPromptly(token => service.GetOverviewAsync("IBM", token));
+    }
+
+    [Test]
+    public void AlphaVantage_GetIntradayRecordsAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var service = CreateAlphaVantageService();
+
+        AssertCancelsPromptly(token => service.GetIntradayRecordsAsync("IBM", StartDate, null, EInterval.Interval_15Min, token));
+    }
+
+    [Test]
+    public void AlphaVantage_GetForexRecordsAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var service = CreateAlphaVantageService();
+
+        AssertCancelsPromptly(token => service.GetForexRecordsAsync("EUR", "USD", StartDate, null, token));
     }
 
     [Test]
@@ -119,6 +180,14 @@ public class CancellationTokenPropagationTests
     }
 
     [Test]
+    public void DataHub_GetSp500InstrumentsAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
+    {
+        var service = new DataHubService(_mockHttpClientFactory.Object, _mockPolicyRegistry.Object);
+
+        AssertCancelsPromptly(service.GetSp500InstrumentsAsync);
+    }
+
+    [Test]
     public void RefreshSessionAsync_Cancelled_StopsWithoutWaitingOutTheBackOff()
     {
         var mockState = new Mock<IYahooSessionState>();
@@ -131,6 +200,23 @@ public class CancellationTokenPropagationTests
             _mockPolicyRegistry.Object);
 
         AssertCancelsPromptly(manager.RefreshSessionAsync);
+    }
+
+    private YahooFinanceService CreateYahooService() => new(
+        Mock.Of<ILogger<YahooFinanceService>>(),
+        _mockHttpClientFactory.Object,
+        _mockPolicyRegistry.Object,
+        Mock.Of<IYahooSessionManager>());
+
+    private AlphaVantageService CreateAlphaVantageService()
+    {
+        var mockOptions = new Mock<IOptions<FinanceNetConfiguration>>();
+        mockOptions.Setup(x => x.Value).Returns(new FinanceNetConfiguration());
+        return new AlphaVantageService(
+            Mock.Of<ILogger<AlphaVantageService>>(),
+            _mockHttpClientFactory.Object,
+            mockOptions.Object,
+            _mockPolicyRegistry.Object);
     }
 
     private static void AssertCancelsPromptly(Func<CancellationToken, Task> call)

--- a/tests/Services/RetryableFailureTests.cs
+++ b/tests/Services/RetryableFailureTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Finance.Net.Exceptions;
+using Finance.Net.Interfaces;
+using Finance.Net.Services;
+using Finance.Net.Utilities;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+using Polly;
+using Polly.Registry;
+
+namespace Finance.Net.Tests.Services;
+
+[TestFixture]
+[Category("Unit")]
+public class RetryableFailureTests
+{
+    private const int RetryCount = 3;
+    private const string ConsentPage =
+        "<html><body><form><h2>Before you continue to Yahoo</h2>" +
+        "<button name='reject'>Reject all</button></form></body></html>";
+
+    private Mock<IHttpClientFactory> _mockHttpClientFactory;
+    private Mock<IReadOnlyPolicyRegistry<string>> _mockPolicyRegistry;
+    private int _requests;
+
+    private void SetUpResponse(HttpStatusCode status, string body, string mediaType)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                _requests++;
+                return new HttpResponseMessage(status) { Content = new StringContent(body, Encoding.UTF8, mediaType) };
+            });
+
+        _mockHttpClientFactory = new Mock<IHttpClientFactory>();
+        _mockHttpClientFactory.Setup(e => e.CreateClient(It.IsAny<string>())).Returns(new HttpClient(mockHandler.Object));
+
+        AsyncPolicy policy = Policy
+            .Handle<Exception>(ex => ex is not FinanceNetNoDataException)
+            .WaitAndRetryAsync(RetryCount, _ => TimeSpan.Zero);
+        IAsyncPolicy asyncPolicy = policy;
+
+        _mockPolicyRegistry = new Mock<IReadOnlyPolicyRegistry<string>>();
+        _mockPolicyRegistry.Setup(registry => registry.Get<AsyncPolicy>(Constants.DefaultHttpRetryPolicy)).Returns(policy);
+        _mockPolicyRegistry.Setup(registry => registry.Get<IAsyncPolicy>(Constants.DefaultHttpRetryPolicy)).Returns(policy);
+        _mockPolicyRegistry.Setup(registry => registry.TryGet(Constants.DefaultHttpRetryPolicy, out asyncPolicy)).Returns(true);
+    }
+
+    private YahooFinanceService CreateService()
+    {
+        var mockSession = new Mock<IYahooSessionManager>();
+        return new YahooFinanceService(
+            Mock.Of<ILogger<YahooFinanceService>>(),
+            _mockHttpClientFactory.Object,
+            _mockPolicyRegistry.Object,
+            mockSession.Object);
+    }
+
+    [SetUp]
+    public void SetUp() => _requests = 0;
+
+    [Test]
+    public void GetSummaryAsync_ConsentPage_KeepsRetrying()
+    {
+        SetUpResponse(HttpStatusCode.OK, ConsentPage, "text/html");
+        var service = CreateService();
+
+        var exception = Assert.ThrowsAsync<FinanceNetException>(async () => await service.GetSummaryAsync("IBM"));
+
+        Assert.That(exception, Is.Not.InstanceOf<FinanceNetNoDataException>());
+        Assert.That(_requests, Is.EqualTo(RetryCount + 1),
+            "the consent page was treated as a permanent no-data answer, so the cookie never got a second chance");
+    }
+
+    [Test]
+    public void GetProfileAsync_ConsentPage_KeepsRetrying()
+    {
+        SetUpResponse(HttpStatusCode.OK, ConsentPage, "text/html");
+        var service = CreateService();
+
+        var exception = Assert.ThrowsAsync<FinanceNetException>(async () => await service.GetProfileAsync("IBM"));
+
+        Assert.That(exception, Is.Not.InstanceOf<FinanceNetNoDataException>());
+        Assert.That(_requests, Is.EqualTo(RetryCount + 1),
+            "the consent page was treated as a permanent no-data answer, so the cookie never got a second chance");
+    }
+
+    [Test]
+    public void GetInstrumentsAsync_ProviderOutage_IsNotReportedAsNoData()
+    {
+        SetUpResponse(HttpStatusCode.ServiceUnavailable, "", "text/html");
+        var service = CreateService();
+
+        var exception = Assert.ThrowsAsync<FinanceNetException>(async () => await service.GetInstrumentsAsync());
+
+        Assert.That(exception, Is.Not.InstanceOf<FinanceNetNoDataException>(),
+            "a 503 told the caller the instrument catalogue is permanently empty");
+        Assert.That(exception.InnerException, Is.Not.Null, "the transport failure was dropped");
+    }
+}

--- a/tests/Services/YahooFinanceServiceTests.cs
+++ b/tests/Services/YahooFinanceServiceTests.cs
@@ -283,9 +283,9 @@ public class YahooFinanceServiceTests
             _mockYahooSession.Object);
 
         // Act
-        var exception = Assert.ThrowsAsync<FinanceNetNoDataException>(async () => await service.GetProfileAsync("IBM"));
-        Assert.That(exception.Message, Does.Contain("No profile data in Yahoo response"));
-        Assert.That(exception.InnerException, Is.Null);
+        var exception = Assert.ThrowsAsync<FinanceNetException>(async () => await service.GetProfileAsync("IBM"));
+        Assert.That(exception, Is.Not.InstanceOf<FinanceNetNoDataException>(), "an unexpected page is not a permanent no-data answer");
+        Assert.That(exception.Message, Does.Contain("No profile found"));
     }
 
     [Test]
@@ -350,9 +350,9 @@ public class YahooFinanceServiceTests
             _mockYahooSession.Object);
 
         // Act
-        var exception = Assert.ThrowsAsync<FinanceNetNoDataException>(async () => await service.GetSummaryAsync("IBM"));
-        Assert.That(exception.Message, Does.Contain("No summary data in Yahoo response"));
-        Assert.That(exception.InnerException, Is.Null);
+        var exception = Assert.ThrowsAsync<FinanceNetException>(async () => await service.GetSummaryAsync("IBM"));
+        Assert.That(exception, Is.Not.InstanceOf<FinanceNetNoDataException>(), "an unexpected page is not a permanent no-data answer");
+        Assert.That(exception.Message, Does.Contain("No summary found"));
     }
 
     [Test]
@@ -513,7 +513,8 @@ public class YahooFinanceServiceTests
             _mockYahooSession.Object);
 
         // Act
-        var exception = Assert.ThrowsAsync<FinanceNetNoDataException>(async () => await service.GetInstrumentsAsync());
+        var exception = Assert.ThrowsAsync<FinanceNetException>(async () => await service.GetInstrumentsAsync());
+        Assert.That(exception, Is.Not.InstanceOf<FinanceNetNoDataException>(), "a transport failure is not a permanent no-data answer");
         Assert.That(exception.Message, Does.Contain("No instruments found"));
     }
 
@@ -530,7 +531,8 @@ public class YahooFinanceServiceTests
             _mockYahooSession.Object);
 
         // Act
-        var exception = Assert.ThrowsAsync<FinanceNetNoDataException>(async () => await service.GetInstrumentsAsync());
+        var exception = Assert.ThrowsAsync<FinanceNetException>(async () => await service.GetInstrumentsAsync());
+        Assert.That(exception, Is.Not.InstanceOf<FinanceNetNoDataException>(), "a transport failure is not a permanent no-data answer");
         Assert.That(exception.Message, Does.Contain("No instruments found"));
     }
 

--- a/tests/Utilities/RetryBackOffTests.cs
+++ b/tests/Utilities/RetryBackOffTests.cs
@@ -22,9 +22,29 @@ namespace Finance.Net.Tests.Utilities;
 public class RetryBackOffTests
 {
     [Test]
-    public void HttpRetrySleepTime_DefaultsToOneSecond()
+    public void HttpRetrySleepTime_DefaultsToFiveSeconds()
     {
-        Assert.That(new FinanceNetConfiguration().HttpRetrySleepTime, Is.EqualTo(1));
+        Assert.That(new FinanceNetConfiguration().HttpRetrySleepTime, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void DefaultConfiguration_SpacesTheFirstRetriesBeyondARateLimitWindow()
+    {
+        var config = new FinanceNetConfiguration();
+        var elapsed = 0.0;
+        var withinTheFirstMinute = 0;
+
+        for (var attempt = 1; attempt <= config.HttpRetryCount; attempt++)
+        {
+            elapsed += PollyPolicyFactory.GetRetryDelay(attempt, config.HttpRetrySleepTime).TotalSeconds;
+            if (elapsed <= 60.0)
+            {
+                withinTheFirstMinute++;
+            }
+        }
+
+        Assert.That(withinTheFirstMinute, Is.LessThanOrEqualTo(3),
+            "retries are packed into the rate-limit window they are meant to wait out");
     }
 
     [Test]
@@ -34,11 +54,10 @@ public class RetryBackOffTests
             .Select(attempt => PollyPolicyFactory.GetRetryDelay(attempt, 1).TotalSeconds)
             .ToList();
 
-        // 1s, 2s, 4s, 8s, each plus up to one base interval of jitter.
         Assert.That(delays[0], Is.InRange(1.0, 2.0));
-        Assert.That(delays[1], Is.InRange(2.0, 3.0));
-        Assert.That(delays[2], Is.InRange(4.0, 5.0));
-        Assert.That(delays[3], Is.InRange(8.0, 9.0));
+        Assert.That(delays[1], Is.InRange(2.0, 4.0));
+        Assert.That(delays[2], Is.InRange(4.0, 8.0));
+        Assert.That(delays[3], Is.InRange(8.0, 16.0));
     }
 
     [Test]
@@ -47,7 +66,24 @@ public class RetryBackOffTests
         var delay = PollyPolicyFactory.GetRetryDelay(20, 1);
 
         Assert.That(delay.TotalSeconds,
-            Is.InRange(PollyPolicyFactory.MaxRetryDelaySecs, PollyPolicyFactory.MaxRetryDelaySecs + 1.0));
+            Is.InRange(PollyPolicyFactory.MaxRetryDelaySecs, PollyPolicyFactory.MaxRetryDelaySecs * 2.0));
+    }
+
+    [Test]
+    public void GetRetryDelay_AtTheCap_JittersAcrossTheWholeDelay()
+    {
+        var spread = Enumerable.Range(0, 200)
+            .Select(_ => PollyPolicyFactory.GetRetryDelay(20, 1).TotalSeconds - PollyPolicyFactory.MaxRetryDelaySecs)
+            .ToList();
+
+        Assert.That(spread.Max(), Is.GreaterThan(PollyPolicyFactory.MaxRetryDelaySecs / 2.0),
+            "jitter is bounded by the base rather than the delay - capped retries stay in lockstep");
+    }
+
+    [Test]
+    public void GetRetryDelay_HugeBase_DoesNotOverflow()
+    {
+        Assert.That(() => PollyPolicyFactory.GetRetryDelay(1, int.MaxValue), Throws.Nothing);
     }
 
     [Test]


### PR DESCRIPTION
Follow-up to the four PRs that landed today. #55, #56, #57 and #58 were merged before their review findings were addressed, so the two functional regressions below are currently on `main`. This fixes them, adds the missing regression tests, and prepares the 1.2.0 release.

## Major fixes

**A Yahoo consent page is retryable again** — `src/Utilities/YahooHtmlParser.cs`

`ParseProfile` and `ParseSummary` are the only two Yahoo parsers with no required field, so any unexpected 200 OK page fell through to `AreAllPropertiesNull` and was reported as `FinanceNetNoDataException`, which #56 excluded from the retry policy. That broke the consent flow: `DeclineConsentAsync` sets the cookie but does not re-fetch, so recovery relied entirely on the next retry. Measured before this fix: 4 requests on `main` before #56, 1 request after it.

Both parsers now check for the `//section/h1` quote header first and throw the retryable `FinanceNetException` when the page is not the expected one. Verified against `tests/TestData/Yahoo/profile.html` and `summary.html`, which both carry that node; the other Yahoo pages have their own structural guards and are untouched.

**A provider outage is no longer reported as an empty catalogue** — `src/Services/YahooFinanceService.cs`

`GetInstrumentsAsync` swallowed every per-type failure and then reported the aggregate as `FinanceNetNoDataException` — the type that means "permanent, stop asking". A 503 from Yahoo told callers the instrument catalogue is permanently empty. The last transport failure is now kept and rethrown as `FinanceNetException` with the original exception attached; `FinanceNetNoDataException` is reserved for the case where every fetch succeeded and genuinely returned nothing.

**The retry back-off default no longer fights rate limits** — `src/FinanceNetConfiguration.cs`

`HttpRetrySleepTime` defaulted to 1 second, which put retries 1-5 at t ≈ 1, 3, 7, 15 and 31 s — all five inside a typical 60 s rate-limit window, where previously only one attempt landed. Since `EnsureSuccessStatusCode()` runs inside the policy, every one of those is a real request: on the Alpha Vantage free tier (25/day) a single failing call burned 20% of the daily quota instead of 4%, while wall-clock recovery was unchanged. The default is now 5 s; the 181 s ceiling that #58 introduced is kept.

## Minor fixes

- `PollyPolicyFactory.GetRetryDelay` — jitter was bounded by the base rather than the computed delay, so once the 30 s cap was reached every caller retried inside the same 1 s window. It now scales with the delay, which also removes the unchecked `int` overflow for large `HttpRetrySleepTime`.
- `GetQuotesAsync` — `WarnAboutUnresolvedSymbols` moved out of the `try`. A throwing logging sink could turn an already-successful fetch into `FinanceNetException`.
- `WarnAboutUnresolvedSymbols` — unresolved symbols are deduplicated, so a duplicate in the request no longer doubles the reported count.
- `Constants.ValidationMessageAllFieldsEmpty` removed; it had no references left after #56.
- German log and exception strings in `XetraService` and `AlphaVantageService` translated to English, per the repo's English-only rule.
- `XetraService.GetDownloadUrl` — dropped a `when (ex is not FinanceNetNoDataException)` filter on a path that cannot throw it.
- XML `<summary>` removed from a private member.
- `.editorconfig` — added `charset = utf-8-bom` for `*.cs`. The ad-hoc BOM removals in #56 and #58 were the sole cause of the merge conflict between them; this makes it a setting rather than a per-PR judgement call. Existing files are not rewritten here.

## Tests

- `tests/Services/RetryableFailureTests.cs` (new) — three cases covering the two major fixes: a consent page keeps being retried for both `GetSummaryAsync` and `GetProfileAsync` (asserting the request count, not just the type), and a 503 during `GetInstrumentsAsync` does not surface as no-data.
- `tests/Services/CancellationTokenPropagationTests.cs` — extended from 6 to 14 cases, covering 14 of the 15 converted call sites (the 15th, `XetraService.GetDownloadUrl`, is private and covered transitively). The wall-clock threshold moved from 1500 ms to 1900 ms; it runs under coverage instrumentation and the Sonar scanner in CI, and the exception-type assertion already separates fixed from broken on its own.
- `tests/Utilities/RetryBackOffTests.cs` — updated for the new default, plus a case asserting that at most three retries land inside a 60 s window, one asserting the jitter spreads across the full delay at the cap, and one for the overflow.
- Four tests in `YahooFinanceServiceTests` asserted the old behaviour and were updated: an unexpected page and a transport failure now assert `FinanceNetException` and explicitly `Is.Not.InstanceOf<FinanceNetNoDataException>()`.

## Verification

| Check | Command | Exit | Result |
|---|---|---|---|
| Build | `dotnet build Finance.NET.slnx --configuration Release` | 0 | `0 Warning(s), 0 Error(s)` |
| CI gate | `dotnet test tests/Tests.csproj -c Release --filter "TestCategory=Unit"` | 0 | `Failed: 0, Passed: 191, Total: 191` |
| New tests guard the fixes | reverted `YahooHtmlParser.cs` and `YahooFinanceService.cs` to `main`, reran | 1 | `Failed: 3, Passed: 0` — all three `RetryableFailureTests` |
| Integration / Long-Running | — | — | NOT CHECKED: live provider endpoints; Alpha Vantage needs `FinanceNet:AlphaVantageApiKey` |
| SonarCloud | — | — | NOT CHECKED locally: no token. The in-build SonarAnalyzer reports 0 warnings |

## Release

Bumps `<Version>` to `1.2.0` and adds `release-notes/v1.2.0.md`. A minor bump rather than a patch: #58 added public API (`HttpRetrySleepTime`), #56 added a public exception type and changed messages and `InnerException` on no-data paths, and #55 changed cancellation to escape as `OperationCanceledException`. All three are called out as breaking in the notes.

`CLAUDE.md` line 44 claimed "All failures are wrapped in `FinanceNetException`", which stopped being true with #56; it now describes the actual contract.